### PR TITLE
Adding automate deployment of a Blazor WebAssembly

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy Blazor WASM to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Publish Blazor WASM
+        run: dotnet publish -c Release -o release
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: release/wwwroot
+          publish_branch: gh-pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy Blazor WASM to GitHub Pages
 
 on:
   push:
-    branches: [main]
+    branches: [master]
 
 jobs:
   build:


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate the deployment of a Blazor WebAssembly (WASM) application to GitHub Pages.

### Deployment automation:
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R1-R28): Introduced a new workflow named "Deploy Blazor WASM to GitHub Pages." It triggers on pushes to the `master` branch and includes steps to check out the source code, set up .NET (version 8.0.x), publish the Blazor WASM application, and deploy it to the `gh-pages` branch using the `peaceiris/actions-gh-pages` action.