### PR TITLE
Update navigation links to use relative URLs

### DIFF
--- a/Layout/MainLayout.razor
+++ b/Layout/MainLayout.razor
@@ -11,10 +11,10 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ms-auto">
                     <li class="nav-item">
-                        <a class="nav-link active" href="/">Hjem</a>
+                        <a class="nav-link active" href="">Hjem</a>
                     </li>
                    <li>
-                       <a class="nav-link active" href="/projekter">Projekter</a>
+                       <a class="nav-link active" href="projekter">Projekter</a>
                    </li>
                 </ul>
             </div>


### PR DESCRIPTION
Changed the `href` attributes in `MainLayout.razor` for the "Hjem" and "Projekter" links from absolute to relative paths. This adjustment may impact link resolution based on the application's current URL structure.